### PR TITLE
Bugfix-change account data record separator

### DIFF
--- a/src/com/razvan/gui/UserTableOperations.java
+++ b/src/com/razvan/gui/UserTableOperations.java
@@ -72,10 +72,10 @@ public class UserTableOperations extends MouseAdapter {
 
 		//Checks to see if the decrypted String contains any values
 		if(!"".equals(decryptedData)) {
-			/* If it contains at least one value then each entry will be split using "," as
+			/* If it contains at least one value then each entry will be split using "|" as
 			  separator and the resulting array will be used to create a new table row */
 			for (String entry : tableData) {
-				dtm.addRow(entry.split(","));
+				dtm.addRow(entry.split("\\|"));
 			}
 		}
 
@@ -416,7 +416,7 @@ public class UserTableOperations extends MouseAdapter {
 					sb.append("\n");
 					break;
 				}
-				sb.append(dtm.getValueAt(i, j) + ",");
+				sb.append(dtm.getValueAt(i, j) + "|");
 			}
 		}
 

--- a/src/com/razvan/gui/WindowBuilder.java
+++ b/src/com/razvan/gui/WindowBuilder.java
@@ -8,7 +8,6 @@ import com.toedter.calendar.JDateChooser;
 import javax.swing.*;
 import javax.swing.GroupLayout.Alignment;
 import javax.swing.event.DocumentEvent;
-import javax.swing.table.DefaultTableModel;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.WindowAdapter;
@@ -220,12 +219,12 @@ public class WindowBuilder extends MouseAdapter implements EditEventListener {
                 fieldContent = formattedDate.toString();
             }
 
-            //The separator "," is added only if the processing has not reached the last object of the array
+            //The separator "|" is added only if the processing has not reached the last object of the array
             if (i != fieldList.size() - 1) {
                 if ("".equals(fieldContent)) {
-                    rowData.append("null" + ",");
+                    rowData.append("null" + "|");
                 } else {
-                    rowData.append(fieldContent + ",");
+                    rowData.append(fieldContent + "|");
 
                 }
             } else {
@@ -266,7 +265,7 @@ public class WindowBuilder extends MouseAdapter implements EditEventListener {
             handler.addNewEntry(rowData);
             UserTableOperations.userOption = JOptionPane.showConfirmDialog(null, "Do you want to insert a new row?", "Data saving", JOptionPane.YES_NO_CANCEL_OPTION);
             if (UserTableOperations.userOption == 0) {
-                handler.getUserDataTableModel().addRow(rowData.split(","));
+                handler.getUserDataTableModel().addRow(rowData.split("\\|"));
                 //Resets the form fields after the new record insertion
                 resetFormFields(fieldList);
             }

--- a/src/com/razvan/installation_manager/ApplicationInstallManager.java
+++ b/src/com/razvan/installation_manager/ApplicationInstallManager.java
@@ -16,7 +16,7 @@ import com.razvan.utils.SenderAccountCredentials;
 import com.razvan.utils.XMLFileReader;
 
 public class ApplicationInstallManager {
-	public static final String APP_MAIN_FOLDER_PATH = System.getProperty("user.home") + "/AppData/Roaming/PasswordVault-test";
+	public static final String APP_MAIN_FOLDER_PATH = System.getProperty("user.home") + "/AppData/Roaming/PasswordVault";
 
 	public static void createAppFoldersAndFiles() {
 

--- a/src/com/razvan/installation_manager/ApplicationInstallManager.java
+++ b/src/com/razvan/installation_manager/ApplicationInstallManager.java
@@ -16,7 +16,7 @@ import com.razvan.utils.SenderAccountCredentials;
 import com.razvan.utils.XMLFileReader;
 
 public class ApplicationInstallManager {
-	public static final String APP_MAIN_FOLDER_PATH = System.getProperty("user.home") + "/AppData/Roaming/PasswordVault";
+	public static final String APP_MAIN_FOLDER_PATH = System.getProperty("user.home") + "/AppData/Roaming/PasswordVault-test";
 
 	public static void createAppFoldersAndFiles() {
 


### PR DESCRIPTION
Changes the data separator character from "," to "|" in order to fix an issue where passwords containing commas were incorrectly split during data processing.